### PR TITLE
Show Trustee re-elections

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,22 +83,30 @@ function drawTrusteeChart() {
         ['Gillian Sinclair', '', palette[5], agm_2022, current],
 
         ['Lyndsey Ballantyne', '', palette[6], agm_2023, current],
-        ['Mary Chester-Kadwell', '', palette[6], agm_2023, current],
-        ['Fliss Guest', '', palette[6], agm_2023, current],
+        ['Mary Chester-Kadwell', '', palette[6], agm_2023, agm_2025],
+        ['Fliss Guest', '', palette[6], agm_2023, agm_2025],
         ['Twin Karmakharm', '', palette[6], agm_2023, current],
         ['Stef Piatek', '', palette[6], agm_2023, current],
         ['Peter Schmidt', '', palette[6], agm_2023, agm_2024],
         ['Mike Simpson', '', palette[6], agm_2023, current],
         
         ['Samantha Ahern', '', palette[7], agm_2024, current],
-        ['Abie Alexander-Ikwue', '', palette[7], agm_2024, current],
+        ['Abie Alexander-Ikwue', '', palette[7], agm_2024, agm_2025],
         ['Philip Grylls', '', palette[7], agm_2024, new Date("2025-06-05")],
-        ['Godwin Yeboah', '', palette[7], agm_2024, current],
+        ['Godwin Yeboah', '', palette[7], agm_2024, agm_2025],
         ['Yo Yehudi', '', palette[7], agm_2024, new Date("2025-01-30")],
 
-        // temporarily appointed after other trustees stood down (2025)
-        ['Kirsty Pringle', '', palette[7], new Date("2025-06-20"), current],
-        ['Marion Weinzierl', '', palette[7], new Date("2025-05-23"), current],
+        // Temporarily appointed after other trustees stood down (2025)
+        ['Kirsty Pringle', '', palette[3], new Date("2025-06-20"), agm_2025],
+        ['Marion Weinzierl', '', palette[3], new Date("2025-05-23"), agm_2025],
+
+        // 2025 New Trustees
+        ['Iain Barrass', '', palette[8], agm_2025, current],
+        ['William Haese-Hill', '', palette[8], agm_2025, current],
+        ['Elena Breitmoser', '', palette[8], agm_2025, current],
+        ['James Tyrrell', '', palette[8], agm_2025, current],
+        ['Mark Basham', '', palette[8], agm_2025, current],
+        ['Adrian Mircea Nenu', '', palette[8], agm_2025, current],
     ];
     dataTable.addRows(trustees);
 
@@ -137,7 +145,7 @@ function drawRoleChart() {
         ['Vice-President', 'David Beavan', agm_2022, agm_2024],
         ['Vice-President', 'Evelina Gabasova', agm_2022, agm_2024],
         ['Vice-President', 'Mike Simpson', agm_2024, current],
-        ['Vice-President', 'Fliss Guest', agm_2024, current],
+        ['Vice-President', 'Fliss Guest', agm_2024, agm_2025],
         
         ['Treasurer', 'Simon Hettrick', founding, agm_2020],
         ['Treasurer', 'Matt Williams', agm_2020, agm_2021],
@@ -151,16 +159,16 @@ function drawRoleChart() {
         ['Vice-Treasurer', 'Fergus Cooper', agm_2021, agm_2022],
         ['Vice-Treasurer', 'Robin Nandi', agm_2022, agm_2023],
         ['Vice-Treasurer', "Martin O'Reilly", agm_2023, agm_2024],
-        ['Vice-Treasurer', 'Godwin Yeboah', agm_2024, current],
+        ['Vice-Treasurer', 'Godwin Yeboah', agm_2024, agm_2025],
         ['Vice-Treasurer', 'Yo Yehudi', agm_2024, new Date("2025-02-20")],
         
         ['Secretary', 'Andrew Turner', founding, agm_2020],
         ['Secretary', 'Teri Forey', agm_2020, agm_2021],
         ['Secretary', 'Mark Turner (Durham)', agm_2021, agm_2022],
-        ['Secretary', 'Gillian Sinclair', agm_2022, current],
+        ['Secretary', 'Gillian Sinclair', agm_2022, agm_2025],
         
         ['Vice-Secretary', 'Fliss Guest', agm_2023, agm_2024],
-        ['Vice-Secretary', 'Stef Piatek', agm_2024, current],
+        ['Vice-Secretary', 'Stef Piatek', agm_2024, agm_2025],
     ]);
 
     var options = {

--- a/index.html
+++ b/index.html
@@ -76,11 +76,11 @@ function drawTrusteeChart() {
         ['Matt Williams', '', palette[4], agm_2021, agm_2024],
         
         ['Alex Coleman', '', palette[5], agm_2022, new Date("2023-06-30")],
-        ['David Beavan', '', palette[5], agm_2022, current],
+        ['David Beavan', '', palette[5], agm_2022, agm_2025],
         ['Evelina Gabasova', '', palette[5], agm_2022, agm_2024],
         ['Robin Nandi', '', palette[5], agm_2022, agm_2024],
-        ["Martin O'Reilly", '', palette[5], agm_2022, current],
-        ['Gillian Sinclair', '', palette[5], agm_2022, current],
+        ["Martin O'Reilly", '', palette[5], agm_2022, agm_2025],
+        ['Gillian Sinclair', '', palette[5], agm_2022, agm_2025],
 
         ['Lyndsey Ballantyne', '', palette[6], agm_2023, current],
         ['Mary Chester-Kadwell', '', palette[6], agm_2023, agm_2025],
@@ -101,6 +101,9 @@ function drawTrusteeChart() {
         ['Marion Weinzierl', '', palette[3], new Date("2025-05-23"), agm_2025],
 
         // 2025 New Trustees
+        ['David Beavan', '', palette[8], agm_2025, current],
+        ["Martin O'Reilly", '', palette[8], agm_2025, current],
+        ['Gillian Sinclair', '', palette[8], agm_2025, current],
         ['Iain Barrass', '', palette[8], agm_2025, current],
         ['William Haese-Hill', '', palette[8], agm_2025, current],
         ['Elena Breitmoser', '', palette[8], agm_2025, current],

--- a/index.html
+++ b/index.html
@@ -97,8 +97,8 @@ function drawTrusteeChart() {
         ['Yo Yehudi', '', palette[7], agm_2024, new Date("2025-01-30")],
 
         // Temporarily appointed after other trustees stood down (2025)
-        ['Kirsty Pringle', '', palette[3], new Date("2025-06-20"), agm_2025],
-        ['Marion Weinzierl', '', palette[3], new Date("2025-05-23"), agm_2025],
+        ['Kirsty Pringle', '', palette[7], new Date("2025-06-20"), agm_2025],
+        ['Marion Weinzierl', '', palette[7], new Date("2025-05-23"), agm_2025],
 
         // 2025 New Trustees
         ['David Beavan', '', palette[8], agm_2025, current],

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@ function drawRoleChart() {
         ['Vice-President', 'Evelina Gabasova', agm_2022, agm_2024],
         ['Vice-President', 'Mike Simpson', agm_2024, current],
         ['Vice-President', 'Fliss Guest', agm_2024, agm_2025],
+        ['Vice-President', 'Samantha Ahern', agm_2025, current],
         
         ['Treasurer', 'Simon Hettrick', founding, agm_2020],
         ['Treasurer', 'Matt Williams', agm_2020, agm_2021],
@@ -161,14 +162,17 @@ function drawRoleChart() {
         ['Vice-Treasurer', "Martin O'Reilly", agm_2023, agm_2024],
         ['Vice-Treasurer', 'Godwin Yeboah', agm_2024, agm_2025],
         ['Vice-Treasurer', 'Yo Yehudi', agm_2024, new Date("2025-02-20")],
+        ['Vice-Treasurer', 'James Tyrrell', agm_2025, current],
         
         ['Secretary', 'Andrew Turner', founding, agm_2020],
         ['Secretary', 'Teri Forey', agm_2020, agm_2021],
         ['Secretary', 'Mark Turner (Durham)', agm_2021, agm_2022],
         ['Secretary', 'Gillian Sinclair', agm_2022, agm_2025],
+        ['Secretary', 'Stef Piatek', agm_2025, current],
         
         ['Vice-Secretary', 'Fliss Guest', agm_2023, agm_2024],
         ['Vice-Secretary', 'Stef Piatek', agm_2024, agm_2025],
+        ['Vice-Secretary', 'William Haese-Hill', agm_2025, current],
     ]);
 
     var options = {


### PR DESCRIPTION
I noticed that, for example, Matt Williams is shown with two different colours, as he was presumably re-elected in 2021.

I've changed Martin, Gillian and Dave, so they should now appear with different cohort colours, as they were all re-elected in 2025.

(Also, I had to merge the changes from main and then reapply the changes for some reason! The only changes should be in the "Show Trustee re-elections" commit)